### PR TITLE
Add drop=FALSE to data frame subsetting to preserve dimensionality wh…

### DIFF
--- a/R/kamila.R
+++ b/R/kamila.R
@@ -707,8 +707,8 @@ kamila <- function(
 
         # cluster test data
         testClust <- kamila(
-           conVar = conVar[testInd,],
-           catFactor = catFactor[testInd,],
+           conVar = conVar[testInd,,drop=FALSE],
+           catFactor = catFactor[testInd,,drop=FALSE],
            numClust = numClust[ithNcInd],
            numInit = numInit,
            conWeights = conWeights,
@@ -721,8 +721,8 @@ kamila <- function(
         
         # cluster training data
         trainClust <- kamila(
-          conVar = conVar[-testInd,],
-          catFactor = catFactor[-testInd,],
+          conVar = conVar[-testInd,,drop=FALSE],
+          catFactor = catFactor[-testInd,,drop=FALSE],
           numClust = numClust[ithNcInd],
           numInit = numInit,
           conWeights = conWeights,
@@ -748,7 +748,7 @@ kamila <- function(
         # Allocate test data based on training clusters.
         teIntoTr <- classifyKamila(
           trainClust,
-          list(conVar[testInd,],catFactor[testInd,])
+          list(conVar[testInd,,drop=FALSE],catFactor[testInd,,drop=FALSE])
         )
         
         # Initialize D matrix.


### PR DESCRIPTION
…en selecting a single column

In the existing code, if there is only a singular categorical or continuous column, subsetting the data frame leads to a loss in dimensionality and subsequent errors from operations that expect a data frame; adding drop=FALSE to these operations will preserve the single column as a data frame with a single column.

P.S. Thank you very much for this excellent package! 